### PR TITLE
Add Image Detection to RMF (Rich Message Formatting)

### DIFF
--- a/frontend-next/src/components/app/datatypes.js
+++ b/frontend-next/src/components/app/datatypes.js
@@ -36,19 +36,27 @@ let dateOptions = {
  * @returns {String} - Formatted Message (IN HTML)
  */
 function RMF(message) {
+  var IMG_END = [".jpg", ".jpeg", ".png", ".gif", ".webp"]
   var URLREGEX = /[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)/g;
   var URLmatch = message.match(URLREGEX);
+  var newMessage = []
   if (URLmatch) {
     for (var i = 0; i < URLmatch.length; i++) {
-      var link = (<span>
-        {message.split(URLmatch[i])[0]}
-        <Link href={"https://"+URLmatch[i]} target="_blank" className="hover:underline">{URLmatch[i]}</Link>
-        {message.split(URLmatch[i])[1]}
-      </span>)
-      message = link
+      if (IMG_END.includes(URLmatch[i].slice(-4)) || IMG_END.includes(URLmatch[i].slice(-5))) {
+        // Its a photo
+        newMessage.push((<img src={"https://"+URLmatch[i]} className="max-w-[100%] max-h-[100%]"/>))
+      } else {
+        console.log(message)
+        newMessage.push((<span className="mr-2">
+          {URLmatch.length == 1 && message.split(URLmatch[i])[0]}
+          <Link href={"https://"+URLmatch[i]} target="_blank" className="hover:underline">{URLmatch[i]}</Link>
+          {(i == URLmatch.length || URLmatch.length == 1) && message.split(URLmatch[i])[1]}
+        </span>))
+      }
+      
     }
   }
-  return message
+  return newMessage
 }
 /**
  * Grabs Window Size


### PR DESCRIPTION
As stated. Works for ".jpg", ".jpeg", ".png", ".gif", ".webp". URL's not ending in those extensions are not detected. The solution is to run a HEAD request on those, but that involves creating a backend API endpoint, and to avoid server overload, moving the image detection from the client recieving messages to the client who sent the message to avoid multiple HEAD requests sent per GIF upload.
![image](https://github.com/ChatMaps/ChatMaps/assets/34464552/b489611e-eaa7-4dc2-a4b4-c1a25e3939a0)
